### PR TITLE
Remove all placeholder text from AboutUs

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -5,19 +5,7 @@ title: About Us
 
 We are a team based in the [School of Computing, National University of Singapore](http://www.comp.nus.edu.sg).
 
-You can reach us at the email `seer[at]comp.nus.edu.sg`
-
 ## Project team
-
-### John Doe
-
-<img src="images/johndoe.png" width="200px">
-
-[[homepage](http://www.comp.nus.edu.sg/~damithch)]
-[[github](https://github.com/johndoe)]
-[[portfolio](team/johndoe.md)]
-
-* Role: Project Advisor
 
 ### Tan Xi Zhe
 


### PR DESCRIPTION
Resolved issue of progressboard not tracking our completed work by removing the placeholder text from our AboutUs.